### PR TITLE
Feat glam support

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -11,7 +11,7 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@master
 
-      - uses: actions/cache@v2
+      - uses: actions/cache@v4
         with:
           path: |
             ~/.cargo/registry

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,6 +20,7 @@ edition = "2018"
 default = ["tokio"]
 
 [dependencies]
+glam = { version = "0.30.0", optional = true }
 nalgebra = { version = ">=0.21.0, <0.34", optional = true }
 prost = "0.13.3"
 tokio = { version = "1.11.0", optional = true, features = ["net"] }

--- a/src/convert.rs
+++ b/src/convert.rs
@@ -28,3 +28,34 @@ macro_rules! impl_bidi_through_ref {
 		impl_through_ref!($trait<$b> for $a);
 	}
 }
+
+#[derive(Copy, Clone, Debug, Eq, PartialEq)]
+pub enum TryFromEgmCartesianSpeedError {
+	WrongNumberOfValues(usize),
+}
+
+#[derive(Copy, Clone, Debug, Eq, PartialEq)]
+pub enum TryFromEgmPoseError {
+	MissingPosition,
+	MissingOrientation,
+}
+
+impl std::fmt::Display for TryFromEgmCartesianSpeedError {
+	fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+		match self {
+			Self::WrongNumberOfValues(x) => write!(f, "wrong number of values, expected 3, got {}", x),
+		}
+	}
+}
+
+impl std::fmt::Display for TryFromEgmPoseError {
+	fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+		match self {
+			Self::MissingPosition => write!(f, "missing field: pos"),
+			Self::MissingOrientation => write!(f, "missing field: orient"),
+		}
+	}
+}
+
+impl std::error::Error for TryFromEgmCartesianSpeedError {}
+impl std::error::Error for TryFromEgmPoseError {}

--- a/src/convert.rs
+++ b/src/convert.rs
@@ -1,0 +1,30 @@
+/// Implement `From<$from> for $for` by delegating to `From<&$from>`.
+#[macro_export]
+macro_rules! impl_through_ref {
+	(From<$from:ty> for $for:ty) => {
+		impl From<$from> for $for {
+			fn from(other: $from) -> Self {
+				(&other).into()
+			}
+		}
+	};
+
+	(TryFrom<$from:ty> for $for:ty) => {
+		impl ::core::convert::TryFrom<$from> for $for {
+			type Error = <Self as ::core::convert::TryFrom<&'static $from>>::Error;
+
+			fn try_from(other: $from) -> Result<Self, Self::Error> {
+				Self::try_from(&other)
+			}
+		}
+	};
+}
+
+/// Implement `$trait<$a> for $b` and `$trait<$b> for $a` by delegating to `$trait<&_>
+#[macro_export]
+macro_rules! impl_bidi_through_ref {
+	($trait:ident, $a:ty, $b:ty) => {
+		impl_through_ref!($trait<$a> for $b);
+		impl_through_ref!($trait<$b> for $a);
+	}
+}

--- a/src/glam.rs
+++ b/src/glam.rs
@@ -41,7 +41,7 @@ impl_through_ref!(TryFrom<msg::EgmCartesianSpeed> for glam::DVec3);
 
 // Quaternion
 
-impl From<&msg::EgmQuaternion> for glam::DQuat{
+impl From<&msg::EgmQuaternion> for glam::DQuat {
 	fn from(other: &msg::EgmQuaternion) -> Self {
 		Self::from_xyzw(other.u0, other.u1, other.u2, other.u3)
 	}

--- a/src/glam.rs
+++ b/src/glam.rs
@@ -55,22 +55,6 @@ impl From<&glam::DQuat> for msg::EgmQuaternion {
 
 impl_bidi_through_ref!(From, msg::EgmQuaternion, glam::DQuat);
 
-// UnitQuaternion
-
-// impl From<&msg::EgmQuaternion> for glam::UnitQuaternion {
-// 	fn from(other: &msg::EgmQuaternion) -> Self {
-// 		Self::from_quaternion(other.into())
-// 	}
-// }
-
-// impl From<&glam::UnitQuaternion> for msg::EgmQuaternion {
-// 	fn from(other: &glam::UnitQuaternion) -> Self {
-// 		other.as_ref().into()
-// 	}
-// }
-
-// impl_bidi_through_ref!(From, msg::EgmQuaternion, glam::UnitQuaternion);
-
 // Rotation3
 
 impl From<&msg::EgmQuaternion> for glam::DAffine3 {

--- a/src/glam.rs
+++ b/src/glam.rs
@@ -1,0 +1,144 @@
+use crate::msg;
+
+use std::convert::TryFrom;
+
+// Vector3
+
+impl From<&msg::EgmCartesian> for glam::DVec3 {
+	fn from(other: &msg::EgmCartesian) -> Self {
+		Self::new(other.x, other.y, other.z)
+	}
+}
+
+impl From<&glam::DVec3> for msg::EgmCartesian {
+	fn from(other: &glam::DVec3) -> Self {
+		Self::from_mm(other.x, other.y, other.z)
+	}
+}
+
+impl TryFrom<&msg::EgmCartesianSpeed> for glam::DVec3 {
+	type Error = TryFromEgmCartesianSpeedError;
+
+	fn try_from(other: &msg::EgmCartesianSpeed) -> Result<Self, Self::Error> {
+		if other.value.len() == 3 {
+			Ok(Self::new(other.value[0], other.value[1], other.value[2]))
+		} else {
+			Err(TryFromEgmCartesianSpeedError::WrongNumberOfValues(other.value.len()))
+		}
+	}
+}
+
+impl From<&glam::DVec3> for msg::EgmCartesianSpeed {
+	fn from(other: &glam::DVec3) -> Self {
+		Self::from_xyz_mm(other.x, other.y, other.z)
+	}
+}
+
+impl_bidi_through_ref!(From, msg::EgmCartesian, glam::DVec3);
+impl_through_ref!(From<glam::DVec3> for msg::EgmCartesianSpeed);
+impl_through_ref!(TryFrom<msg::EgmCartesianSpeed> for glam::DVec3);
+
+// Quaternion
+
+impl From<&msg::EgmQuaternion> for glam::DQuat{
+	fn from(other: &msg::EgmQuaternion) -> Self {
+		Self::from_xyzw(other.u0, other.u1, other.u2, other.u3)
+	}
+}
+
+impl From<&glam::DQuat> for msg::EgmQuaternion {
+	fn from(other: &glam::DQuat) -> Self {
+		Self::from_wxyz(other.w, other.x, other.y, other.z)
+	}
+}
+
+impl_bidi_through_ref!(From, msg::EgmQuaternion, glam::DQuat);
+
+// UnitQuaternion
+
+// impl From<&msg::EgmQuaternion> for glam::UnitQuaternion {
+// 	fn from(other: &msg::EgmQuaternion) -> Self {
+// 		Self::from_quaternion(other.into())
+// 	}
+// }
+
+// impl From<&glam::UnitQuaternion> for msg::EgmQuaternion {
+// 	fn from(other: &glam::UnitQuaternion) -> Self {
+// 		other.as_ref().into()
+// 	}
+// }
+
+// impl_bidi_through_ref!(From, msg::EgmQuaternion, glam::UnitQuaternion);
+
+// Rotation3
+
+impl From<&msg::EgmQuaternion> for glam::DAffine3 {
+	fn from(other: &msg::EgmQuaternion) -> Self {
+        glam::DAffine3::from_quat(glam::DQuat::from(other))
+	}
+}
+
+impl From<&glam::DAffine3> for msg::EgmQuaternion {
+	fn from(other: &glam::DAffine3) -> Self {
+		glam::DQuat::from_affine3(other).into()
+	}
+}
+
+impl_bidi_through_ref!(From, msg::EgmQuaternion, glam::DAffine3);
+
+// Isometry3
+
+impl TryFrom<&msg::EgmPose> for glam::DAffine3 {
+	type Error = TryFromEgmPoseError;
+
+	fn try_from(other: &msg::EgmPose) -> Result<Self, Self::Error> {
+		let position = other.pos.as_ref().ok_or(Self::Error::MissingPosition)?;
+		let orientation = other.orient.as_ref().ok_or(Self::Error::MissingOrientation)?;
+
+		Ok(glam::DAffine3::from_rotation_translation(
+            orientation.into(),
+			glam::DVec3::from(position).into(),
+		))
+	}
+}
+
+impl From<&glam::DAffine3> for msg::EgmPose {
+	fn from(other: &glam::DAffine3) -> Self {
+        let (_, rotation, translation) = other.to_scale_rotation_translation();
+		Self::new(translation, rotation)
+	}
+}
+
+impl_through_ref!(From<glam::DAffine3> for msg::EgmPose);
+impl_through_ref!(TryFrom<msg::EgmPose> for glam::DAffine3);
+
+#[derive(Copy, Clone, Debug, Eq, PartialEq)]
+pub enum TryFromEgmCartesianSpeedError {
+	WrongNumberOfValues(usize),
+}
+
+#[derive(Copy, Clone, Debug, Eq, PartialEq)]
+pub enum TryFromEgmPoseError {
+	MissingPosition,
+	MissingOrientation,
+}
+
+impl std::fmt::Display for TryFromEgmCartesianSpeedError {
+	fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+		match self {
+			Self::WrongNumberOfValues(x) => write!(f, "wrong number of values, expected 3, got {}", x),
+		}
+	}
+}
+
+impl std::fmt::Display for TryFromEgmPoseError {
+	fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+		match self {
+			Self::MissingPosition => write!(f, "missing field: pos"),
+			Self::MissingOrientation => write!(f, "missing field: orient"),
+		}
+	}
+}
+
+impl std::error::Error for TryFromEgmCartesianSpeedError {}
+impl std::error::Error for TryFromEgmPoseError {}

--- a/src/glam.rs
+++ b/src/glam.rs
@@ -1,5 +1,6 @@
 use crate::msg;
 
+use crate::convert::{TryFromEgmCartesianSpeedError, TryFromEgmPoseError};
 use std::convert::TryFrom;
 
 // Vector3
@@ -97,7 +98,7 @@ impl TryFrom<&msg::EgmPose> for glam::DAffine3 {
 
 		Ok(glam::DAffine3::from_rotation_translation(
             orientation.into(),
-			glam::DVec3::from(position).into(),
+			glam::DVec3::from(position),
 		))
 	}
 }
@@ -111,34 +112,3 @@ impl From<&glam::DAffine3> for msg::EgmPose {
 
 impl_through_ref!(From<glam::DAffine3> for msg::EgmPose);
 impl_through_ref!(TryFrom<msg::EgmPose> for glam::DAffine3);
-
-#[derive(Copy, Clone, Debug, Eq, PartialEq)]
-pub enum TryFromEgmCartesianSpeedError {
-	WrongNumberOfValues(usize),
-}
-
-#[derive(Copy, Clone, Debug, Eq, PartialEq)]
-pub enum TryFromEgmPoseError {
-	MissingPosition,
-	MissingOrientation,
-}
-
-impl std::fmt::Display for TryFromEgmCartesianSpeedError {
-	fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
-		match self {
-			Self::WrongNumberOfValues(x) => write!(f, "wrong number of values, expected 3, got {}", x),
-		}
-	}
-}
-
-impl std::fmt::Display for TryFromEgmPoseError {
-	fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
-		match self {
-			Self::MissingPosition => write!(f, "missing field: pos"),
-			Self::MissingOrientation => write!(f, "missing field: orient"),
-		}
-	}
-}
-
-impl std::error::Error for TryFromEgmCartesianSpeedError {}
-impl std::error::Error for TryFromEgmPoseError {}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -48,6 +48,9 @@ pub use error::SendError;
 
 mod generated;
 
+#[macro_use]
+mod convert;
+
 /// Generated protobuf messages used by EGM.
 pub mod msg {
 	pub use super::generated::*;
@@ -63,6 +66,10 @@ pub mod tokio_peer;
 /// Conversions to/from nalgebra types.
 #[cfg(feature = "nalgebra")]
 mod nalgebra;
+
+/// Conversions to/from glam types.
+#[cfg(feature = "glam")]
+mod glam;
 
 impl msg::EgmHeader {
 	pub fn new(seqno: u32, timestamp_ms: u32, kind: msg::egm_header::MessageType) -> Self {

--- a/src/nalgebra.rs
+++ b/src/nalgebra.rs
@@ -1,5 +1,6 @@
 use crate::msg;
 
+use crate::convert::{TryFromEgmCartesianSpeedError, TryFromEgmPoseError};
 use std::convert::TryFrom;
 
 // Vector3
@@ -110,34 +111,3 @@ impl From<&nalgebra::Isometry3<f64>> for msg::EgmPose {
 
 impl_through_ref!(From<nalgebra::Isometry3<f64>> for msg::EgmPose);
 impl_through_ref!(TryFrom<msg::EgmPose> for nalgebra::Isometry3<f64>);
-
-#[derive(Copy, Clone, Debug, Eq, PartialEq)]
-pub enum TryFromEgmCartesianSpeedError {
-	WrongNumberOfValues(usize),
-}
-
-#[derive(Copy, Clone, Debug, Eq, PartialEq)]
-pub enum TryFromEgmPoseError {
-	MissingPosition,
-	MissingOrientation,
-}
-
-impl std::fmt::Display for TryFromEgmCartesianSpeedError {
-	fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
-		match self {
-			Self::WrongNumberOfValues(x) => write!(f, "wrong number of values, expected 3, got {}", x),
-		}
-	}
-}
-
-impl std::fmt::Display for TryFromEgmPoseError {
-	fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
-		match self {
-			Self::MissingPosition => write!(f, "missing field: pos"),
-			Self::MissingOrientation => write!(f, "missing field: orient"),
-		}
-	}
-}
-
-impl std::error::Error for TryFromEgmCartesianSpeedError {}
-impl std::error::Error for TryFromEgmPoseError {}

--- a/src/nalgebra.rs
+++ b/src/nalgebra.rs
@@ -1,34 +1,6 @@
 use crate::msg;
+
 use std::convert::TryFrom;
-
-/// Implement `From<$from> for $for` by delegating to `From<&$from>`.
-macro_rules! impl_through_ref {
-	(From<$from:ty> for $for:ty) => {
-		impl From<$from> for $for {
-			fn from(other: $from) -> Self {
-				(&other).into()
-			}
-		}
-	};
-
-	(TryFrom<$from:ty> for $for:ty) => {
-		impl ::core::convert::TryFrom<$from> for $for {
-			type Error = <Self as ::core::convert::TryFrom<&'static $from>>::Error;
-
-			fn try_from(other: $from) -> Result<Self, Self::Error> {
-				Self::try_from(&other)
-			}
-		}
-	};
-}
-
-/// Implement `$trait<$a> for $b` and `$trait<$b> for $a` by delegating to `$trait<&_>
-macro_rules! impl_bidi_through_ref {
-	($trait:ident, $a:ty, $b:ty) => {
-		impl_through_ref!($trait<$a> for $b);
-		impl_through_ref!($trait<$b> for $a);
-	}
-}
 
 // Vector3
 


### PR DESCRIPTION
Added support for type conversions between mathematical constructs defined in `glam` and the `egm` protocol. This follows a very similar pattern to the support for `nalgebra` types.